### PR TITLE
Store comments as entities in Datastore

### DIFF
--- a/portfolio/pom.xml
+++ b/portfolio/pom.xml
@@ -28,6 +28,11 @@
       <artifactId>gson</artifactId>
       <version>2.8.6</version>
     </dependency>
+    <dependency>
+      <groupId>com.google.appengine</groupId>
+      <artifactId>appengine-api-1.0-sdk</artifactId>
+      <version>1.9.59</version>
+    </dependency>
   </dependencies>
 
   <build>

--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -14,6 +14,9 @@
 
 package com.google.sps.servlets;
 
+import com.google.appengine.api.datastore.DatastoreService;
+import com.google.appengine.api.datastore.DatastoreServiceFactory;
+import com.google.appengine.api.datastore.Entity;
 import com.google.gson.Gson;
 
 import java.io.IOException;
@@ -38,12 +41,23 @@ public class DataServlet extends HttpServlet {
   @Override
   public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
     String message = request.getParameter("message");
+
     if (message.length() == 0) {
         response.sendError(HttpServletResponse.SC_FORBIDDEN, "empty message");
     }
     else {
         messages.add(message);
         messages_json = convertToJsonUsingGson(messages);
+ 
+        long timestamp = System.currentTimeMillis();
+
+        Entity commentEntity = new Entity("Comment");
+        commentEntity.setProperty("message", message);
+        commentEntity.setProperty("timestamp", timestamp);
+        
+        DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
+        datastore.put(commentEntity);
+
         response.sendRedirect("/index.html");
     }
   }

--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -49,12 +49,12 @@ public class DataServlet extends HttpServlet {
         messages.add(message);
         messages_json = convertToJsonUsingGson(messages);
  
-        long timestamp = System.currentTimeMillis();
+        final long timestamp = System.currentTimeMillis();
 
         Entity commentEntity = new Entity("Comment");
         commentEntity.setProperty("message", message);
         commentEntity.setProperty("timestamp", timestamp);
-        
+
         DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
         datastore.put(commentEntity);
 


### PR DESCRIPTION
Part 1 from the Week 2, Step 5 walkthrough.
- Add App Engine dependency in `pom.xml`
- Store comment entities in Datastore
  - confirmed by checking the admin page after posting a comment