### PR TITLE
Display comments by querying Datastore

### DIFF
--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -17,6 +17,9 @@ package com.google.sps.servlets;
 import com.google.appengine.api.datastore.DatastoreService;
 import com.google.appengine.api.datastore.DatastoreServiceFactory;
 import com.google.appengine.api.datastore.Entity;
+import com.google.appengine.api.datastore.PreparedQuery;
+import com.google.appengine.api.datastore.Query;
+import com.google.appengine.api.datastore.Query.SortDirection;
 import com.google.gson.Gson;
 
 import java.io.IOException;
@@ -26,14 +29,23 @@ import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-/** Servlet that returns some example content. TODO: modify this file to handle comments data */
+/** Servlet that handles comments data */
 @WebServlet("/data")
 public class DataServlet extends HttpServlet {
-  private ArrayList<String> messages = new ArrayList<String>();
-  private String messages_json = null;
-
   @Override
-  public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {    
+  public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
+    Query query = new Query("Comment").addSort("timestamp", SortDirection.DESCENDING);
+
+    DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
+    PreparedQuery results = datastore.prepare(query);
+
+    ArrayList<String> messages = new ArrayList<>();
+    for (Entity entity : results.asIterable()) {
+      String message = (String) entity.getProperty("message");
+      messages.add(message);
+    }
+    String messages_json = convertToJsonUsingGson(messages);
+
     response.setContentType("application/json;");
     response.getWriter().println(messages_json);
   }
@@ -46,9 +58,6 @@ public class DataServlet extends HttpServlet {
         response.sendError(HttpServletResponse.SC_FORBIDDEN, "empty message");
     }
     else {
-        messages.add(message);
-        messages_json = convertToJsonUsingGson(messages);
- 
         final long timestamp = System.currentTimeMillis();
 
         Entity commentEntity = new Entity("Comment");

--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -41,13 +41,11 @@ public class DataServlet extends HttpServlet {
 
     ArrayList<String> messages = new ArrayList<>();
     for (Entity entity : results.asIterable()) {
-      String message = (String) entity.getProperty("message");
-      messages.add(message);
+      messages.add((String) entity.getProperty("message"));
     }
-    String messages_json = convertToJsonUsingGson(messages);
 
     response.setContentType("application/json;");
-    response.getWriter().println(messages_json);
+    response.getWriter().println(convertToJsonUsingGson(messages));
   }
 
   @Override


### PR DESCRIPTION
Complete the Week 2 walkthrough.

Originally, the servlet uses class variable to store messages.
Now, it retrieves messages from Datastore when `doGet` is called.

The comments are now permanently stored in Datastore, tested by shutting down and reopening the server.